### PR TITLE
add go-srpm-macros to default collectd buildroot

### DIFF
--- a/templates/cbs-tools/scripts/sigs/opstools/collectd/config.sh
+++ b/templates/cbs-tools/scripts/sigs/opstools/collectd/config.sh
@@ -1,0 +1,1 @@
+BUILDROOT_DEFAULT="go-srpm-macros bash bzip2 coreutils cpio diffutils redhat-release findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed unzip util-linux-ng git which buildsys-tools xz"


### PR DESCRIPTION
Similar to cloud SIG, buildroot has been modified for future collectd versions.