### PR TITLE
Enable kojihub plugins

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,8 +110,11 @@ koji_admin_keytab: koji-admin.keytab # Needed only if koji_auth_kerberos above a
 # - fedmsg-koji-plugin  # sending to fedora-messaging/rabbitmq, only for specific builders
 # Each plugin can have its own config, see below
 koji_hub_plugins: True
-koji_hub_plugins_list: []
-koji_hub_noconfig_plugins_list: []
+koji_hub_plugins_list:
+  - fedmsg-koji-plugin
+koji_hub_noconfig_plugins_list:
+  - runroot_hub
+  - sidetag_hub
 
 # Now the plugins settings, if needed
 # centmsg / mqtt


### PR DESCRIPTION
fedmsg-koji-plugin is part of this role.  runroot_hub and sidetag_hub are included since koji 1.21, and are already installed by this role.